### PR TITLE
Fix ipopt 3.14.5

### DIFF
--- a/dice2016.py
+++ b/dice2016.py
@@ -206,7 +206,7 @@ def dice2016(**kwargs):
             return (kwargs['optlrsav'], kwargs['optlrsav'])
 
     # Variables and their scopes
-    model.MIU = pe.Var(model.time_periods, domain=pe.NonNegativeReals, bounds=miu_bounds) 
+    model.MIU = pe.Var(model.time_periods, domain=pe.NonNegativeReals, bounds=miu_bounds, initialize=kwargs['miu0']) 
     model.FORC = pe.Var(model.time_periods, domain=pe.Reals)
     # difference here: I define TATM over Reals, because TATM < 0 is possible
     model.TATM = pe.Var(model.time_periods, domain=pe.Reals, bounds=tatm_bounds)
@@ -217,7 +217,7 @@ def dice2016(**kwargs):
     model.E = pe.Var(model.time_periods, domain=pe.Reals) 
     model.EIND = pe.Var(model.time_periods, domain=pe.Reals) 
     model.C = pe.Var(model.time_periods, domain=pe.NonNegativeReals, bounds=c_bounds) 
-    model.K = pe.Var(model.time_periods, domain=pe.NonNegativeReals, bounds=k_bounds) 
+    model.K = pe.Var(model.time_periods, domain=pe.NonNegativeReals, bounds=k_bounds, initialize=kwargs['k0']) 
     model.CPC = pe.Var(model.time_periods, domain=pe.NonNegativeReals, bounds=cpc_bounds) 
     model.I = pe.Var(model.time_periods, domain=pe.NonNegativeReals) 
     model.S = pe.Var(model.time_periods, domain=pe.Reals, bounds=s_bounds) 

--- a/dice2016_parameters.csv
+++ b/dice2016_parameters.csv
@@ -52,4 +52,4 @@ scale1,0.030245527,Multiplicative scaling coefficient
 scale2,-10993.704,Additive scaling coefficient
 fosslim,6000,Maximum cumulative extraction fossil fuels (GtC)
 dmiulim,0.2,Limit on change in miu
-logfile,0,Dump solver log?
+logfile,1,Dump solver log?

--- a/dice2016_parameters.csv
+++ b/dice2016_parameters.csv
@@ -52,4 +52,4 @@ scale1,0.030245527,Multiplicative scaling coefficient
 scale2,-10993.704,Additive scaling coefficient
 fosslim,6000,Maximum cumulative extraction fossil fuels (GtC)
 dmiulim,0.2,Limit on change in miu
-logfile,1,Dump solver log?
+logfile,0,Dump solver log?

--- a/environment.yml
+++ b/environment.yml
@@ -5,4 +5,4 @@ dependencies:
   - pyomo
   - pandas
   - numpy
-  - ipopt==3.11.1  # https://stackoverflow.com/questions/64912995/applicationerror-no-executable-found-for-solver-ipopt-in-pyomo
+  - ipopt==3.14.5  # https://stackoverflow.com/questions/64912995/applicationerror-no-executable-found-for-solver-ipopt-in-pyomo


### PR DESCRIPTION
2 line fix - initialising variables MIU and K using miu0 and k0, seems to allow the model to run with more recent ipopt